### PR TITLE
(GH-27) Moved disqus logic to its own javascript file

### DIFF
--- a/input/_PostFooter.cshtml
+++ b/input/_PostFooter.cshtml
@@ -1,4 +1,4 @@
 <div id="disqus_thread"></div>
-<script type="text/javascript" src="~/assets/js/disqus.js"></script>
+<script type="text/javascript" src="~/assets/js/disqus.js" async></script>
 <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>

--- a/input/_PostFooter.cshtml
+++ b/input/_PostFooter.cshtml
@@ -1,24 +1,4 @@
 <div id="disqus_thread"></div>
-<script type="text/javascript">
-    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-    var disqus_shortname = 'aberdeendevelopersnetusergroup'; // required: replace example with your forum shortname
-    var disqus_identifier = '@Model.FilePath(Keys.RelativeFilePath).FileNameWithoutExtension.FullPath';
-    var disqus_title = '@Model.String(BlogKeys.Title)';
-    var disqus_url = '@Context.GetLink(Model, true)';
-
-    /* * * DON'T EDIT BELOW THIS LINE * * */
-    (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-    })();
-    
-    (function () {
-        var s = document.createElement('script'); s.async = true;
-        s.type = 'text/javascript';
-        s.src = '//' + disqus_shortname + '.disqus.com/count.js';
-        (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
-    }());
-</script>
+<script type="text/javascript" src="~/assets/js/disqus.js"></script>
 <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>

--- a/input/assets/js/disqus.js
+++ b/input/assets/js/disqus.js
@@ -1,0 +1,33 @@
+/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+var metaElements = document.getElementsByTagName('meta');
+
+var disqus_shortname = 'aberdeendevelopersnetusergroup'; // required: replace example with your forum shortname
+var disqus_identifier;
+var disqus_title;
+var disqus_url;
+
+for (var i = 0; i < metaElements.length; i++) {
+    var element = metaElements[i];
+    var propAttribute = element.getAttribute('property');
+    if (propAttribute === 'og:title') {
+        disqus_title = element.getAttribute('content');
+    }
+    else if (propAttribute === 'og:url') {
+        disqus_url = element.getAttribute('content');
+        disqus_identifier = disqus_url.split(/\//).pop();
+    }
+}
+
+/* * * DON'T EDIT BELOW THIS LINE * * */
+(function() {
+    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+})();
+
+(function () {
+    var s = document.createElement('script'); s.async = true;
+    s.type = 'text/javascript';
+    s.src = '//' + disqus_shortname + '.disqus.com/count.js';
+    (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
+}());


### PR DESCRIPTION
This pull request moves the logic of creating the disqus comment section to its own javascript file instead of having the logic embedded inside the html file directly.

It adds the necessary logic to extract the title, url and identifier from the `og` meta tags. (Didn't want to use the url directly, as this could be different depending on wether https or http is used).

**NOTE:** You may wish to force the `og` meta tags generated to force the usage of https urls (currently they use http no matter what).

// cc: @gep13 